### PR TITLE
fix(ui): adjust new connection window center

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+remmina (1.4.34+dfsg-1deepin2) unstable; urgency=medium
+
+  * chore: Update version to 1.4.34+dfsg-1deepin2
+  * fix(ui): adjust new connection window center
+
+ -- zhanghongyuan <zhanghongyuan@uniontech.com>  Thu, 12 Feb 2026 10:28:30 +0800
+
 remmina (1.4.34+dfsg-1deepin1) unstable; urgency=medium
 
   * fix(ui): center dialogs on screen when displayed

--- a/debian/patches/0002-Adjust-New-Connection-Window-Center.patch
+++ b/debian/patches/0002-Adjust-New-Connection-Window-Center.patch
@@ -1,0 +1,14 @@
+Index: remmina/src/remmina_file_editor.c
+===================================================================
+--- remmina.orig/src/remmina_file_editor.c
++++ remmina/src/remmina_file_editor.c
+@@ -1945,7 +1945,8 @@ static void remmina_file_editor_init(Rem
+ 
+ 	gtk_dialog_set_default_response(GTK_DIALOG(gfe), GTK_RESPONSE_OK);
+ 	gtk_window_set_default_size(GTK_WINDOW(gfe), 800, 600);
+-
++	gtk_window_set_position(GTK_WINDOW(gfe), GTK_WIN_POS_CENTER);
++	
+ 	g_signal_connect(G_OBJECT(gfe), "destroy", G_CALLBACK(remmina_file_editor_destroy), NULL);
+ 	g_signal_connect(G_OBJECT(gfe), "realize", G_CALLBACK(remmina_file_editor_on_realize), NULL);
+ 

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,1 +1,2 @@
 0001-Center-Dialogs-On-Screen-When-Displayed.patch
+0002-Adjust-New-Connection-Window-Center.patch


### PR DESCRIPTION
adjust new connection window center

log: center dialogs on screen when displayed
bug: https://pms.uniontech.com/bug-view-303725.html